### PR TITLE
fix(account_billing_alert): fix deprecated threshold

### DIFF
--- a/modules/account_billing_alert/README.md
+++ b/modules/account_billing_alert/README.md
@@ -7,13 +7,13 @@ The module is intended to be used in a subaccount, not in a root account which s
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.51.0 |
 
 ## Modules
 

--- a/modules/account_billing_alert/cost_anomaly_detection.tf
+++ b/modules/account_billing_alert/cost_anomaly_detection.tf
@@ -8,8 +8,15 @@ resource "aws_ce_anomaly_monitor" "service_monitor" {
 resource "aws_ce_anomaly_subscription" "service_monitor_subscritpion" {
   count     = var.anomaly_detection_threshold == 0 ? 0 : 1
   name      = "DAILYSUBSCRIPTION"
-  threshold = var.anomaly_detection_threshold
   frequency = "DAILY"
+
+  threshold_expression {
+    dimension {
+      key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
+      match_options = ["GREATER_THAN_OR_EQUAL"]
+      values        = [var.anomaly_detection_threshold]
+    }
+  }
 
   monitor_arn_list = [
     aws_ce_anomaly_monitor.service_monitor[0].arn,

--- a/modules/account_billing_alert/requirements.tf
+++ b/modules/account_billing_alert/requirements.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0.0"
   required_providers {
     aws = {
-      version = ">= 4.30.0"
+      version = ">= 4.51.0"
     }
   }
 }


### PR DESCRIPTION
Hi all,

When using `account_billing_alert` module with a more recent version of AWS provider, the parameter `threshold` in the resource `aws_ce_anomaly_subscription` is no longer available.

`threshold` was deprecated on version [4.51.0](https://github.com/hashicorp/terraform-provider-aws/blob/release/4.x/CHANGELOG.md#4510-january-19-2023) with their [pull request](https://github.com/hashicorp/terraform-provider-aws/pull/28573) and replaced by `threshold_expression`.